### PR TITLE
Fix for API error using libxml2 as the parser for libstrophe

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,6 @@ lib_LIBRARIES = libstrophe.a
 endif
 
 libstrophe_a_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
-libstrophe_a_include_HEADERS = strophe.h
 libstrophe_a_SOURCES = src/auth.c src/conn.c src/ctx.c \
 	src/event.c src/handler.c src/hash.c \
 	src/jid.c src/md5.c src/sasl.c src/sha1.c \

--- a/README.txt
+++ b/README.txt
@@ -8,18 +8,24 @@ Our goals are:
 
 == Build Instructions ==
 
-We use the 'scons' tool to build the library, unit tests, 
-documentation and examples. You'll need to obtain a copy
-from http://www.scons.org/ or from your system distributor.
+From the top-level directory, run the following commands
 
-Once scons is installed, invoke 'scons' in the top-level
-directory to build the library. This will create a static
-library (also in the top-level) directory which can be
-linked into other programs. The public api is defined
-in <strophe.h> which is also in the top-level directory.
+NOTE: By default libstrophe uses expat as it's XML parser.
+You may pass in --with-libxml2 with the ./configure command
+to switch to using libxml2 as your XML parser.
 
-Invoke 'scons test' in the top-level directory to execute
-the unit and self tests.
+$ ./bootstrap.sh
+
+$ ./configure
+or
+$ ./configure --with-libxml2
+
+$ make
+
+This will create a static library, also in the top-level
+directory, which can be linked into other programs. The 
+public api is defined in <strophe.h> which is also in the
+top-level directory.
 
 The examples/ directory contains some examples of how to
 use the library; these may be helpful in addition to the

--- a/README.txt
+++ b/README.txt
@@ -6,6 +6,17 @@ Our goals are:
     * well documented
     * reliable
 
+== GIT Instructions ==
+
+By default, libstrophe has a dependency on the XML parsing
+library expat.  Expat is included as a submodule of this
+repository.  After cloning this repository, you will need
+to run the following to acquire the expat submodule:
+
+$ git submodule init
+
+$ git submodule update
+
 == Build Instructions ==
 
 From the top-level directory, run the following commands

--- a/src/parser_libxml2.c
+++ b/src/parser_libxml2.c
@@ -202,5 +202,11 @@ int parser_reset(parser_t *parser)
 /* feed a chunk of data to the parser */
 int parser_feed(parser_t *parser, char *chunk, int len)
 {
-    return xmlParseChunk(parser->xmlctx, chunk, len, 0);
+     /* xmlParseChunk API returns 0 on success which is opposite logic to
+       the status returned by parser_feed */
+    if(!xmlParseChunk(parser->xmlctx, chunk, len, 0)) {
+        return 1;
+    } else {
+        return 0;
+    }
 }


### PR DESCRIPTION
Jack,

The error I encountered was a simple API error as you anticipated.  The fix is contained in parser_libxml2.c.

While I was submitting patches, I updated the README.txt to reflect the current build steps.  I also made a change to Makefile.am that caused by build to fail (specifically the ./configure operation would fail).  I don't know why this change was required for me.

Let me know if you'd like these changes as actual patches.  I thought pulling from my fork might be easier for you.

Thanks,

Russ
