### PR TITLE
Event system refactorizations to allow for optional external event loops

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ PARSER_CFLAGS=@PARSER_CFLAGS@
 PARSER_LIBS=@PARSER_LIBS@
 
 STROPHE_FLAGS = -I$(top_srcdir)
-STROPHE_LIBS = libstrophe.a $(PARSER_LIBS) -lssl -lresolv
+STROPHE_LIBS = libstrophe.a $(PARSER_LIBS) -lssl
 
 ## Main build targets
 if BUILD_EXPAT

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ libstrophe_la_LDFLAGS = -version-info 1:0:1
 libstrophe_la_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
 libstrophe_ladir=$(includedir)/
 libstrophe_la_HEADERS=strophe.h strophepp.h
+noinst_HEADERS=src/*.h
 libstrophe_la_SOURCES = src/auth.c src/conn.c src/ctx.c \
 	src/event.c src/handler.c src/hash.c \
 	src/jid.c src/md5.c src/sasl.c src/sha1.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,25 +9,28 @@ PARSER_CFLAGS=@PARSER_CFLAGS@
 PARSER_LIBS=@PARSER_LIBS@
 
 STROPHE_FLAGS = -I$(top_srcdir)
-STROPHE_LIBS = libstrophe.a $(PARSER_LIBS) -lssl
+STROPHE_LIBS = libstrophe.la $(PARSER_LIBS) -lssl
 
 ## Main build targets
 if BUILD_EXPAT
-lib_LIBRARIES = libstrophe.a libexpat.a
-else
-lib_LIBRARIES = libstrophe.a
+lib_LIBRARIES = libexpat.a
 endif
+lib_LTLIBRARIES = libstrophe.la
 
-libstrophe_a_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
-libstrophe_a_SOURCES = src/auth.c src/conn.c src/ctx.c \
+# Note: version is <current>:<revision>:<age>, age _MUST_ be less than <current>
+#       (this is not an arbitrary value, see libtool documentation for more information.)
+#                   http://sourceware.org/autobook/autobook/autobook_91.html
+libstrophe_la_LDFLAGS = -version-info 1:0:1
+libstrophe_la_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_la_SOURCES = src/auth.c src/conn.c src/ctx.c \
 	src/event.c src/handler.c src/hash.c \
 	src/jid.c src/md5.c src/sasl.c src/sha1.c \
 	src/snprintf.c src/sock.c src/stanza.c src/thread.c \
 	src/tls_openssl.c src/util.c
 if PARSER_EXPAT
-libstrophe_a_SOURCES += src/parser_expat.c
+libstrophe_la_SOURCES += src/parser_expat.c
 else
-libstrophe_a_SOURCES += src/parser_libxml2.c
+libstrophe_la_SOURCES += src/parser_libxml2.c
 endif
 
 libexpat_a_CFLAGS=-DXML_DTD -DXML_NS -DXML_CONTEXT_BYTES=1024 -DXML_STATIC \

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,8 @@ lib_LTLIBRARIES = libstrophe.la
 #                   http://sourceware.org/autobook/autobook/autobook_91.html
 libstrophe_la_LDFLAGS = -version-info 1:0:1
 libstrophe_la_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_ladir=$(includedir)/
+libstrophe_la_HEADERS=strophe.h strophepp.h
 libstrophe_la_SOURCES = src/auth.c src/conn.c src/ctx.c \
 	src/event.c src/handler.c src/hash.c \
 	src/jid.c src/md5.c src/sasl.c src/sha1.c \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 aclocal
+libtoolize
 automake --add-missing --foreign --copy
 autoconf

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 aclocal
 automake --add-missing --foreign --copy

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_INIT([libstrophe], [trunk], [jack@metajack.im])
 AM_INIT_AUTOMAKE
 
+LT_INIT
 AC_PROG_CC
-AC_PROG_RANLIB
 AM_PROG_CC_C_O
 
 AC_CHECK_HEADER(openssl/ssl.h, [], [AC_MSG_ERROR([couldn't find openssl headers, openssl required])])
@@ -26,12 +26,15 @@ if test "x$with_libxml2" = xyes; then
   PARSER_NAME=libxml2
   PARSER_CFLAGS=\$\(libxml2_CFLAGS\)
   PARSER_LIBS=\$\(libxml2_LIBS\)
+  AC_CHECK_LIB(xml2, xmlFree, [], [AC_MSG_ERROR("libxml2 not found")])
 else
   with_parser=builtin
   PARSER_NAME=expat
   PARSER_CFLAGS=\$\(builtin_CFLAGS\)
   PARSER_LIBS=\$\(builtin_LIBS\)
 fi
+
+AC_CHECK_LIB(ssl, ssl_verify_cert_chain, [], [AC_MSG_ERROR("libssl not found")])
 
 # Check for the resolv library (needed on linux systems)
 AC_CHECK_LIB(resolv, __res_query)

--- a/configure.ac
+++ b/configure.ac
@@ -6,11 +6,10 @@ AC_PROG_RANLIB
 AM_PROG_CC_C_O
 
 AC_CHECK_HEADER(openssl/ssl.h, [], [AC_MSG_ERROR([couldn't find openssl headers, openssl required])])
-PKG_CHECK_MODULES([check], [check >= 0.9.4])
 
 AC_ARG_WITH([libxml2], 
             [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing])],
-            [with_libxml2=check],
+            [with_libxml2=yes],
             [with_libxml2=no])
 
 if test "x$with_libxml2" != xno; then

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,9 @@ else
   PARSER_LIBS=\$\(builtin_LIBS\)
 fi
 
+# Check for the resolv library (needed on linux systems)
+AC_CHECK_LIB(resolv, __res_query)
+
 AC_MSG_NOTICE([libstrophe will use the $with_parser XML parser])
 AC_SEARCH_LIBS([socket], [socket])
 

--- a/src/auth.c
+++ b/src/auth.c
@@ -788,7 +788,9 @@ static int _handle_features_sasl(xmpp_conn_t * const conn,
 	    }
 	    xmpp_stanza_set_text(text, resource);
 	    xmpp_stanza_add_child(res, text);
+	    xmpp_stanza_release(text);
 	    xmpp_stanza_add_child(bind, res);
+	    xmpp_stanza_release(res);
 	    xmpp_free(conn->ctx, resource);
 	}
 

--- a/src/common.h
+++ b/src/common.h
@@ -23,7 +23,15 @@
 #include <stdarg.h>
 #ifndef _WIN32
 #include <stdint.h>
+#include <sys/select.h>
+#include <errno.h>
+#else
+#include <winsock2.h>
+#define ETIMEDOUT WSAETIMEDOUT
+#define ECONNRESET WSAECONNRESET
+#define ECONNABORTED WSAECONNABORTED
 #endif
+
 
 
 #include "strophe.h"
@@ -159,7 +167,7 @@ struct _xmpp_conn_t {
     uint64_t timeout_stamp;
     int error;
     xmpp_stream_error_t *stream_error;
-    sock_t sock;
+    xmpp_sock_t sock;
     tls_t *tls;
 
     int tls_support;
@@ -206,6 +214,10 @@ struct _xmpp_conn_t {
     /* connection events handler */
     xmpp_conn_handler conn_handler;
     void *userdata;
+
+    void (*write_callback)(struct _xmpp_conn_t * const, void *);
+    void *write_callback_userdata;
+
 
     /* other handlers */
     xmpp_handlist_t *timed_handlers;

--- a/src/conn.c
+++ b/src/conn.c
@@ -270,7 +270,7 @@ int xmpp_conn_release(xmpp_conn_t * const conn)
 
 	if (conn->domain) xmpp_free(ctx, conn->domain);
 	if (conn->jid) xmpp_free(ctx, conn->jid);
-    if (conn->bound_jid) xmpp_free(ctx, conn->bound_jid);
+	if (conn->bound_jid) xmpp_free(ctx, conn->bound_jid);
 	if (conn->pass) xmpp_free(ctx, conn->pass);
 	if (conn->stream_id) xmpp_free(ctx, conn->stream_id);
 	if (conn->lang) xmpp_free(ctx, conn->lang);

--- a/src/handler.c
+++ b/src/handler.c
@@ -105,7 +105,7 @@ void handler_fire_stanza(xmpp_conn_t * const conn,
 	if ((!item->ns || (ns && strcmp(ns, item->ns) == 0) ||
 	     xmpp_stanza_get_child_by_ns(stanza, item->ns)) &&
 	    (!item->name || (name && strcmp(name, item->name) == 0)) &&
-	    (!item->type || (type && strcmp(type, item->type) == 0)))
+	    (!item->type || (type && strcmp(type, item->type) == 0))) {
 	    if (!((xmpp_handler)(item->handler))(conn, stanza, item->userdata)) {
 		/* handler is one-shot, so delete it */
 		if (prev)
@@ -118,6 +118,7 @@ void handler_fire_stanza(xmpp_conn_t * const conn,
 		xmpp_free(conn->ctx, item);
 		item = NULL;
 	    }
+        }
 	
 	if (item) {
 	    prev = item;

--- a/src/sock.c
+++ b/src/sock.c
@@ -74,9 +74,9 @@ static int _in_progress(int error)
 #endif
 }
 
-sock_t sock_connect(const char * const host, const unsigned int port)
+xmpp_sock_t sock_connect(const char * const host, const unsigned int port)
 {
-    sock_t sock;
+    xmpp_sock_t sock;
     char service[6];
     struct addrinfo *res, *ainfo, hints;
     int err;
@@ -113,7 +113,7 @@ sock_t sock_connect(const char * const host, const unsigned int port)
     return sock;
 }
 
-int sock_close(const sock_t sock)
+int sock_close(const xmpp_sock_t sock)
 {
 #ifdef _WIN32
     return closesocket(sock);
@@ -122,7 +122,7 @@ int sock_close(const sock_t sock)
 #endif
 }
 
-int sock_set_blocking(const sock_t sock)
+int sock_set_blocking(const xmpp_sock_t sock)
 {
 #ifdef _WIN32
     u_long block = 0;
@@ -132,7 +132,7 @@ int sock_set_blocking(const sock_t sock)
 #endif
 }
 
-int sock_set_nonblocking(const sock_t sock)
+int sock_set_nonblocking(const xmpp_sock_t sock)
 {
 #ifdef _WIN32
     u_long nonblock = 1;
@@ -142,12 +142,12 @@ int sock_set_nonblocking(const sock_t sock)
 #endif
 }
 
-int sock_read(const sock_t sock, void * const buff, const size_t len)
+int sock_read(const xmpp_sock_t sock, void * const buff, const size_t len)
 {
     return recv(sock, buff, len, 0);
 }
 
-int sock_write(const sock_t sock, const void * const buff, const size_t len)
+int sock_write(const xmpp_sock_t sock, const void * const buff, const size_t len)
 {
     return send(sock, buff, len, 0);
 }
@@ -162,7 +162,7 @@ int sock_is_recoverable(const int error)
 #endif
 }
 
-int sock_connect_error(const sock_t sock)
+int sock_connect_error(const xmpp_sock_t sock)
 {
     struct sockaddr sa;
     unsigned len;
@@ -588,7 +588,7 @@ int sock_srv_lookup(const char *service, const char *proto, const char *domain, 
 	struct dnsquery_question question;
 	int offset = 0;
 	int addrlen;
-	sock_t sock;
+	xmpp_sock_t sock;
 	struct sockaddr_in dnsaddr;
 	char dnsserverips[16][256];
 	int numdnsservers = 0;

--- a/src/sock.h
+++ b/src/sock.h
@@ -20,29 +20,23 @@
 #define __LIBSTROPHE_SOCK_H__
 
 #include <stdio.h>
-
-#ifndef _WIN32
-typedef int sock_t;
-#else
-#include <winsock2.h>
-typedef SOCKET sock_t;
-#endif
+#include "../strophe.h"
 
 void sock_initialize(void);
 void sock_shutdown(void);
 
 int sock_error(void);
 
-sock_t sock_connect(const char * const host, const unsigned int port);
-int sock_close(const sock_t sock);
+xmpp_sock_t sock_connect(const char * const host, const unsigned int port);
+int sock_close(const xmpp_sock_t sock);
 
-int sock_set_blocking(const sock_t sock);
-int sock_set_nonblocking(const sock_t sock);
-int sock_read(const sock_t sock, void * const buff, const size_t len);
-int sock_write(const sock_t sock, const void * const buff, const size_t len);
+int sock_set_blocking(const xmpp_sock_t sock);
+int sock_set_nonblocking(const xmpp_sock_t sock);
+int sock_read(const xmpp_sock_t sock, void * const buff, const size_t len);
+int sock_write(const xmpp_sock_t sock, const void * const buff, const size_t len);
 int sock_is_recoverable(const int error);
 /* checks for an error after connect, return 0 if connect successful */
-int sock_connect_error(const sock_t sock);
+int sock_connect_error(const xmpp_sock_t sock);
 
 int sock_srv_lookup(const char *service, const char *proto,
 		     const char *domain, char *resulttarget,

--- a/src/tls.h
+++ b/src/tls.h
@@ -27,7 +27,7 @@ typedef struct _tls tls_t;
 void tls_initialize(void);
 void tls_shutdown(void);
 
-tls_t *tls_new(xmpp_ctx_t *ctx, sock_t sock);
+tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock);
 void tls_free(tls_t *tls);
 
 int tls_set_credentials(tls_t *tls, const char *cafilename);

--- a/src/tls_dummy.c
+++ b/src/tls_dummy.c
@@ -22,7 +22,7 @@
 
 struct _tls {
     xmpp_ctx_t *ctx; /* do we need this? */
-    sock_t sock;
+    xmpp_sock_t sock;
     /* we don't implement anything */
 };
 
@@ -36,7 +36,7 @@ void tls_shutdown(void)
     return;
 }
 
-tls_t *tls_new(xmpp_ctx_t *ctx, sock_t sock)
+tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock)
 {
     /* always fail */
     return NULL;

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -24,7 +24,7 @@
 
 struct _tls {
     xmpp_ctx_t *ctx; /* do we need this? */
-    sock_t sock;
+    xmpp_sock_t sock;
     gnutls_session_t session;
     gnutls_certificate_credentials_t cred;
 };
@@ -45,7 +45,7 @@ void tls_shutdown(void)
     gnutls_global_deinit();
 }
 
-tls_t *tls_new(xmpp_ctx_t *ctx, sock_t sock)
+tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock)
 {
     tls_t *tls = xmpp_alloc(ctx, sizeof(tls_t));
     const int cert_type_priority[3] = { GNUTLS_CRT_X509,

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -33,7 +33,7 @@
 
 struct _tls {
     xmpp_ctx_t *ctx;
-    sock_t sock;
+    xmpp_sock_t sock;
     SSL_CTX *ssl_ctx;
     SSL *ssl;
     int lasterror;
@@ -55,7 +55,7 @@ int tls_error(tls_t *tls)
     return tls->lasterror;
 }
 
-tls_t *tls_new(xmpp_ctx_t *ctx, sock_t sock)
+tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock)
 {
     tls_t *tls = xmpp_alloc(ctx, sizeof(*tls));
 

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -87,6 +87,7 @@ tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock)
 
 void tls_free(tls_t *tls)
 {
+    SSL_free(tls->ssl);
     SSL_CTX_free(tls->ssl_ctx);
     xmpp_free(tls->ctx, tls);
     return;

--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -26,7 +26,7 @@
 
 struct _tls {
     xmpp_ctx_t *ctx;
-    sock_t sock;
+    xmpp_sock_t sock;
 
     HANDLE hsec32;
     SecurityFunctionTable *sft;
@@ -63,7 +63,7 @@ void tls_shutdown(void)
     return;
 }
 
-tls_t *tls_new(xmpp_ctx_t *ctx, sock_t sock)
+tls_t *tls_new(xmpp_ctx_t *ctx, xmpp_sock_t sock)
 {
     tls_t *tls;
     PSecurityFunctionTable (*pInitSecurityInterface)(void);

--- a/strophe.h
+++ b/strophe.h
@@ -164,8 +164,7 @@ typedef struct _xmpp_stanza_t xmpp_stanza_t;
 /* connect callback */
 typedef enum {
     XMPP_CONN_CONNECT,
-    XMPP_CONN_DISCONNECT,
-    XMPP_CONN_FAIL
+    XMPP_CONN_DISCONNECT
 } xmpp_conn_event_t;
 
 typedef enum {

--- a/strophe.h
+++ b/strophe.h
@@ -273,6 +273,22 @@ void xmpp_id_handler_delete(xmpp_conn_t * const conn,
 			    xmpp_handler handler,
 			    const char * const id);
 
+/* Event hooks and functions for people wanting to use their own event IO system */
+#ifndef _WIN32
+typedef int xmpp_sock_t;
+#else
+#include <winsock2.h>
+typedef SOCKET xmpp_sock_t;
+#endif
+
+void xmpp_conn_set_write_callback(xmpp_conn_t * const conn,
+                                  void (*callback)(xmpp_conn_t * const conn, void * userdata),
+                                  void *userdata);
+void xmpp_conn_read(xmpp_conn_t * const conn);
+void xmpp_conn_write(xmpp_conn_t * const conn);
+xmpp_sock_t xmpp_conn_get_socket(xmpp_conn_t * const conn);
+
+
 /*
 void xmpp_register_stanza_handler(conn, stanza, xmlns, type, handler)
 */


### PR DESCRIPTION
Hey metajack,

Love the library.

I moved some code around and added a few functions to allow people to tie into your library but use their own event loop. I found your library very useful when putting together some stress tests, but i needed to beyond what a select loop could offer, so I made these modifications, tied in to libevent (which uses epoll/kqueue/etc), and was able to spin up tens of thousands of connections with ease. 

The API for your built in event loop remains intact and functions exactly as it did before.

I also made a couple of changes to the autotools build files to enable builds on FreeBSD and to make the dynamic and static versions of the library, and the two header files, more easily installable.
- Akita
