### PR TITLE
Fix logging when stanzas are too big

### DIFF
--- a/src/ctx.c
+++ b/src/ctx.c
@@ -250,10 +250,13 @@ void xmpp_log(const xmpp_ctx_t * const ctx,
     int oldret, ret;
     char smbuf[1024];
     char *buf;
+    va_list copy;
 
     buf = smbuf;
+    va_copy(copy, ap);
     ret = xmpp_vsnprintf(buf, 1023, fmt, ap);
     if (ret > 1023) {
+	va_copy(ap, copy);
 	buf = (char *)xmpp_alloc(ctx, ret + 1);
 	if (!buf) {
 	    buf = NULL;


### PR DESCRIPTION
If you try to send a stanza with a **lot** of data in it (in my example, I do 10000 chars), libstrophe seg faults.  I've included a test file (https://gist.github.com/1202353); you'll need an XMPP server running on localhost with the JID `rob@localhost` on it with the password `abc123` to run the test.  I tested against Prosody 0.8.2.
