### PR TITLE
Bug when using SSL communication

### DIFF
--- a/src/tls.h
+++ b/src/tls.h
@@ -37,6 +37,7 @@ int tls_stop(tls_t *tls);
 
 int tls_error(tls_t *tls);
 
+int tls_pending(tls_t *tls);
 int tls_read(tls_t *tls, void * const buff, const size_t len);
 int tls_write(tls_t *tls, const void * const buff, const size_t len);
 

--- a/src/tls_dummy.c
+++ b/src/tls_dummy.c
@@ -68,6 +68,11 @@ int tls_error(tls_t *tls)
     return 0;
 }
 
+int tls_pending(tls_t *tls)
+{
+    return 0;
+}
+
 int tls_read(tls_t *tls, void * const buff, const size_t len)
 {
     return -1;

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -107,6 +107,11 @@ int tls_error(tls_t *tls)
     return 0;
 }
 
+int tls_pending(tls_t *tls)
+{
+    return gnutls_record_check_pending (tls->session);
+}
+
 int tls_read(tls_t *tls, void * const buff, const size_t len)
 {
     int ret;

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -152,6 +152,11 @@ int tls_is_recoverable(int error)
 	    || error == SSL_ERROR_WANT_ACCEPT);
 }
 
+int tls_pending(tls_t *tls)
+{
+    return SSL_pending(tls->ssl);
+}
+
 int tls_read(tls_t *tls, void * const buff, const size_t len)
 {
     int ret = SSL_read(tls->ssl, buff, len);

--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -398,6 +398,22 @@ int tls_is_recoverable(int error)
 	    || error == WSAEINPROGRESS);
 }
 
+int tls_pending(tls_t *tls) {
+	// There are 3 cases:
+	// - there is data in ready buffer, so it is by default pending
+	// - there is data in recv buffer. If it is not decrypted yet, means it 
+	// was incomplete. This should be processed again only if there is data
+	// on the physical connection
+	// - there is data on the physical connection. This case is treated
+	// outside the tls (in event.c)
+
+    if (tls->readybufferpos < tls->readybufferlen) {
+		return tls->readybufferlen - tls->readybufferpos;
+	}
+
+	return 0;
+}
+
 int tls_read(tls_t *tls, void * const buff, const size_t len)
 {
     int bytes;


### PR DESCRIPTION
In event.c the processing of new data is not working always for SSL connections.

More specifically, the select is made on the 'real' socket (conn->sock), not on the encrypted one. More over there is a 4096 bytes buffer read for each return of select. The following scenario will not work in case of SSL connections:
- 'real' sockets receives 8000 bytes.
- select detects the available data, but the connection is SSL so tls_read is invoked. 
- tls_read reads 8000 bytes, decrypts them and puts them in an internal buffer
- tls_read returns the first 4096 bytes
- at next select call, the program does not do anything as there is no data on the 'real' socket.

The fix adds a new function "tls_pending" which will return the number of bytes that can be returned from the descrypted tls buffer. I provided implementations for all 3 tls backends, but tested only openssl and windows. The gnutls implementation is trivial so probably there will not be problems with it.
