### PR TITLE
Option to disable TLS

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -209,9 +209,13 @@ static int _handle_features(xmpp_conn_t * const conn,
 
     /* check for TLS */
     if (!conn->secured) {
-        child = xmpp_stanza_get_child_by_name(stanza, "starttls");
-        if (child && (strcmp(xmpp_stanza_get_ns(child), XMPP_NS_TLS) == 0))
-            conn->tls_support = 1;
+        if (!conn->tls_disabled) {
+            child = xmpp_stanza_get_child_by_name(stanza, "starttls");
+            if (child && (strcmp(xmpp_stanza_get_ns(child), XMPP_NS_TLS) == 0))
+                conn->tls_support = 1;
+        } else {
+            conn->tls_disabled = 0;
+        }
     }
 
     /* check for SASL */

--- a/src/common.h
+++ b/src/common.h
@@ -163,6 +163,7 @@ struct _xmpp_conn_t {
     tls_t *tls;
 
     int tls_support;
+    int tls_disabled;
     int tls_failed; /* set when tls fails, so we don't try again */
     int sasl_support; /* if true, field is a bitfield of supported 
 			 mechanisms */ 

--- a/src/conn.c
+++ b/src/conn.c
@@ -109,6 +109,7 @@ xmpp_conn_t *xmpp_conn_new(xmpp_ctx_t * const ctx)
         conn->bound_jid = NULL;
 
 	conn->tls_support = 0;
+    conn->tls_disabled = 0;
 	conn->tls_failed = 0;
 	conn->sasl_support = 0;
         conn->secured = 0;
@@ -664,6 +665,17 @@ void conn_open_stream(xmpp_conn_t * const conn)
 			 conn->lang,
 			 conn->type == XMPP_CLIENT ? XMPP_NS_CLIENT : XMPP_NS_COMPONENT,
 			 XMPP_NS_STREAMS);
+}
+
+/** Disable TLS for this connection, called by users of the library.
+ *  Occasionally a server will be misconfigured to send the starttls
+ *  feature, but wil not support the handshake.
+ *
+ *  @param conn a Strophe connection object
+ */
+void xmpp_conn_disable_tls(xmpp_conn_t * const conn)
+{
+    conn->tls_disabled = 1;
 }
 
 static void _log_open_tag(xmpp_conn_t *conn, char **attrs)

--- a/strophe.h
+++ b/strophe.h
@@ -217,6 +217,7 @@ void xmpp_conn_set_jid(xmpp_conn_t * const conn, const char * const jid);
 const char *xmpp_conn_get_pass(const xmpp_conn_t * const conn);
 void xmpp_conn_set_pass(xmpp_conn_t * const conn, const char * const pass);
 xmpp_ctx_t* xmpp_conn_get_context(xmpp_conn_t * const conn);
+void xmpp_conn_disable_tls(xmpp_conn_t * const conn);
 
 int xmpp_connect_client(xmpp_conn_t * const conn, 
 			  const char * const altdomain,


### PR DESCRIPTION
I've had a problem with a certain server advertising that it supports TLS by returning the TLS feature, but then doesn't respond to the handshake.

Unfortunately I can't find out much about the server.

I originally tried adding a timeout on the handshake, but the coding got pretty low level inside the tls_start function and a much simpler solution seemed to add a TLS disable flag on the connection object.  This works with my jabber client that now has the option to call xmpp_conn_disable_tls.

It'd be great if you could put this change in so I can carry on working with your repo rather than my fork.  If you have any comments/suggestions of a better way let me know.

Thanks,

James.
