### PR TITLE
xmpp_graceful_stop(ctx,timeout) + fix for send_queue_len

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -148,6 +148,7 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long timeout)
 	    xmpp_free(ctx, sq->data);
 	    tsq = sq;
 	    sq = sq->next;
+	    conn->send_queue_len--;
 	    xmpp_free(ctx, tsq);
 
 	    /* pop the top item */

--- a/src/event.c
+++ b/src/event.c
@@ -350,3 +350,35 @@ void xmpp_stop(xmpp_ctx_t *ctx)
     if (ctx->loop_status == XMPP_LOOP_RUNNING)
 	ctx->loop_status = XMPP_LOOP_QUIT;
 }
+void xmpp_graceful_stop(xmpp_ctx_t *ctx, const unsigned long timeout)
+{
+    xmpp_connlist_t *connitem;
+    xmpp_conn_t *conn;
+    xmpp_conn_t *c;
+    xmpp_debug(ctx, "event", "Gracefully Stopping event loop.");
+    uint64_t then = time_stamp();
+    int sent_data;
+    /* We loop through each connection calling xmpp_run_once each
+     * time we find a connection with enqueued data until we loop
+     * through all connections once without finding any data to send 
+     * or until we exceed the passed in timeout.
+     */
+    if (ctx->loop_status == XMPP_LOOP_RUNNING) {
+	for (;;) {
+	    sent_data = 0;
+	    for (connitem=ctx->connlist;connitem;connitem=connitem->next) {
+		conn=connitem->conn;
+		if (!conn || conn->send_queue_len == 0)
+		    continue;
+		xmpp_run_once(ctx, 1);
+	        sent_data++;
+		if (time_stamp() - then > timeout)
+		    break;
+	    }
+	    if (sent_data == 0)
+		break;
+	}
+	xmpp_debug(ctx, "event", "Finished Gracefully Stopping Event Loop");
+	ctx->loop_status = XMPP_LOOP_QUIT;
+    }
+}

--- a/strophe.h
+++ b/strophe.h
@@ -366,6 +366,7 @@ void xmpp_presence_new();
 void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long  timeout);
 void xmpp_run(xmpp_ctx_t *ctx);
 void xmpp_stop(xmpp_ctx_t *ctx);
+void xmpp_graceful_stop(xmpp_ctx_t *ctx, const unsigned long timeout);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
xmpp_graceful_stop(ctx,timeout) waits until either all connections have a send_queue_len of zero or timeout elapses.  The primary motivation is to have an easy way to signal shutdown after any enqueued messages have been sent.  The previous commit, adds a one line fix to decrement send_queue_len so it contains the length of the queue.

This works for my simple program, let me know if this looks correct to you.

Garick
