### PR TITLE
Fixed sock_read bug when returning 0 values on Windows.

### DIFF
--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -455,11 +455,10 @@ int tls_read(tls_t *tls, void * const buff, const size_t len)
     bytes = sock_read(tls->sock, tls->recvbuffer + tls->recvbufferpos,
 		      tls->recvbuffermaxlen - tls->recvbufferpos);
 			  
-	if (bytes == 0)
-	{
-		tls->lasterror = WSAETIMEDOUT;
-		return -1;
-	}				  
+    if (bytes == 0) {
+        tls->lasterror = WSAETIMEDOUT;
+        return -1;
+    }				  
 
     if (bytes == -1) {
 	if (!tls_is_recoverable(sock_error())) {

--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -454,6 +454,12 @@ int tls_read(tls_t *tls, void * const buff, const size_t len)
     /* next, top up our recv buffer */
     bytes = sock_read(tls->sock, tls->recvbuffer + tls->recvbufferpos,
 		      tls->recvbuffermaxlen - tls->recvbufferpos);
+			  
+	if (bytes == 0)
+	{
+		tls->lasterror = WSAETIMEDOUT;
+		return -1;
+	}				  
 
     if (bytes == -1) {
 	if (!tls_is_recoverable(sock_error())) {


### PR DESCRIPTION
sock_read on Windows returns 0 when an error occurs.
